### PR TITLE
fixed chainscat range differ error in 11_Turing_tricks.jl

### DIFF
--- a/_literate/11_Turing_tricks.jl
+++ b/_literate/11_Turing_tricks.jl
@@ -115,7 +115,8 @@ chain_qr = sample(model_qr, NUTS(1_000, 0.65), MCMCThreads(), 2_000, 4)
 # Now we have to reconstruct our $\boldsymbol{\beta}$s:
 
 betas = mapslices(x -> R_ast^-1 * x, chain_qr[:, namesingroup(chain_qr, :β),:].value.data, dims=[2])
-chain_qr_reconstructed = hcat(Chains(betas, ["real_β[$i]" for i in 1:size(Q_ast, 2)]), chain_qr)
+chain_beta = setrange(Chains(betas, ["real_β[$i]" for i in 1:size(Q_ast, 2)]), 1_001:1:3_000)
+chain_qr_reconstructed = hcat(chain_beta, chain_qr)
 
 # ## Non-Centered Parametrization
 


### PR DESCRIPTION
This fixes the `ArgumentError: chain ranges differ` in the **QR Decomposition** section of tutorial **11 - Computational Tricks with Turing**.