### PR TITLE
Fixed Turing @model to functions

### DIFF
--- a/_literate/10_multilevel_models.jl
+++ b/_literate/10_multilevel_models.jl
@@ -95,7 +95,7 @@ using Random:seed!
 seed!(123)
 setprogress!(false) # hide
 
-@model varying_intercept(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2)) = begin
+@model function varying_intercept(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2))
     #priors
     α ~ Normal(mean(y), 2.5 * std(y))       # population-level intercept
     β ~ filldist(Normal(0, 2), predictors)  # population-level coefficients
@@ -135,7 +135,7 @@ end;
 
 # In Turing we can accomplish this as:
 
-@model varying_slope(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2)) = begin
+@model function varying_slope(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2))
     #priors
     α ~ Normal(mean(y), 2.5 * std(y))                   # population-level intercept
     σ ~ Exponential(1 / std(y))                         # residual SD
@@ -175,7 +175,7 @@ end;
 
 # In Turing we can accomplish this as:
 
-@model varying_intercept_slope(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2)) = begin
+@model function varying_intercept_slope(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2))
     #priors
     α ~ Normal(mean(y), 2.5 * std(y))                    # population-level intercept
     σ ~ Exponential(1 / std(y))                          # residual SD

--- a/_literate/11_Turing_tricks.jl
+++ b/_literate/11_Turing_tricks.jl
@@ -49,7 +49,7 @@ using Random:seed!
 seed!(123)
 setprogress!(false) # hide
 
-@model linreg(X, y; predictors=size(X, 2)) = begin
+@model function function linreg(X, y; predictors=size(X, 2)
     #priors
     α ~ Normal(mean(y), 2.5 * std(y))
     β ~ filldist(TDist(3), predictors)
@@ -144,7 +144,7 @@ savefig(joinpath(@OUTPUT, "funnel.svg")); # hide
 
 # To see the devil's funnel (how it is known in some Bayesian circles) in action, let's code it in Turing and then sample:
 
-@model funnel() = begin
+@model function funnel()
     y ~ Normal(0, 3)
     x ~ Normal(0, exp(y / 2))
 end
@@ -162,7 +162,7 @@ end
 # This is why is called Non-Centered Parametrization because we "decouple" the parameters and
 # reconstruct them before.
 
-@model ncp_funnel() = begin
+@model function ncp_funnel()
     x̃ ~ Normal()
     ỹ ~ Normal()
     y = 3.0 * ỹ         # implies y ~ Normal(0, 3)
@@ -177,7 +177,7 @@ chain_ncp_funnel = sample(ncp_funnel(), NUTS(), MCMCThreads(), 2_000, 4)
 # in [10. **Multilevel Models (a.k.a. Hierarchical Models)**](/pages/10_multilevel_models/). Here was the
 # approach that we took, also known as Centered Parametrization (CP):
 
-@model varying_intercept(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2)) = begin
+@model function varying_intercept(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2))
     #priors
     α ~ Normal(mean(y), 2.5 * std(y))       # population-level intercept
     β ~ filldist(Normal(0, 2), predictors)  # population-level coefficients
@@ -194,7 +194,7 @@ end;
 
 # To perform a Non-Centered Parametrization (NCP) in this model we do as following:
 
-@model varying_intercept_ncp(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2)) = begin
+@model function varying_intercept_ncp(X, idx, y; n_gr=length(unique(idx)), predictors=size(X, 2))
     #priors
     α ~ Normal(mean(y), 2.5 * std(y))       # population-level intercept
     β ~ filldist(Normal(0, 2), predictors)  # population-level coefficients

--- a/_literate/12_epi_models.jl
+++ b/_literate/12_epi_models.jl
@@ -153,7 +153,7 @@ using Random:seed!
 seed!(123)
 setprogress!(false) # hide
 
-@model bayes_sir(infected, i₀, r₀, N) = begin
+@model function bayes_sir(infected, i₀, r₀, N)
     #calculate number of timepoints
     l = length(infected)
 

--- a/_literate/4_Turing.jl
+++ b/_literate/4_Turing.jl
@@ -107,7 +107,7 @@ savefig(joinpath(@OUTPUT, "dice.svg")); # hide
 using Turing
 setprogress!(false) # hide
 
-@model dice_throw(y) = begin
+@model function dice_throw(y)
     #Our prior belief about the probability of each result in a six-sided dice.
     #p is a vector of length 6 each with probability p that sums up to 1.
     p ~ Dirichlet(6, 1)

--- a/_literate/5_MCMC.jl
+++ b/_literate/5_MCMC.jl
@@ -1137,7 +1137,7 @@ savefig(joinpath(@OUTPUT, "funnel.svg")); # hide
 using Turing
 setprogress!(false) # hide
 
-@model dice_throw(y) = begin
+@model function dice_throw(y)
     #Our prior belief about the probability of each result in a six-sided dice.
     #p is a vector of length 6 each with probability p that sums up to 1.
     p ~ Dirichlet(6, 1)

--- a/_literate/6_linear_reg.jl
+++ b/_literate/6_linear_reg.jl
@@ -77,7 +77,7 @@ using Random:seed!
 seed!(123)
 setprogress!(false) # hide
 
-@model linreg(X, y; predictors=size(X, 2)) = begin
+@model function linreg(X, y; predictors=size(X, 2))
     #priors
     α ~ Normal(mean(y), 2.5 * std(y))
     β ~ filldist(TDist(3), predictors)

--- a/_literate/7_logistic_reg.jl
+++ b/_literate/7_logistic_reg.jl
@@ -135,7 +135,7 @@ using Random:seed!
 seed!(123)
 setprogress!(false) # hide
 
-@model logreg(X,  y; predictors=size(X, 2)) = begin
+@model function logreg(X,  y; predictors=size(X, 2))
     #priors
     α ~ Normal(0, 2.5)
     β ~ filldist(TDist(3), predictors)

--- a/_literate/8_count_reg.jl
+++ b/_literate/8_count_reg.jl
@@ -117,7 +117,7 @@ using Random:seed!
 seed!(123)
 setprogress!(false) # hide
 
-@model poissonreg(X,  y; predictors=size(X, 2)) = begin
+@model function poissonreg(X,  y; predictors=size(X, 2))
     #priors
     α ~ Normal(0, 2.5)
     β ~ filldist(TDist(3), predictors)
@@ -253,7 +253,7 @@ end
 
 # Now we create our Turing model with the alternative `NegBinomial2` parameterization:
 
-@model negbinreg(X,  y; predictors=size(X, 2)) = begin
+@model function negbinreg(X,  y; predictors=size(X, 2))
     #priors
     α ~ Normal(0, 2.5)
     β ~ filldist(TDist(3), predictors)

--- a/_literate/9_robust_reg.jl
+++ b/_literate/9_robust_reg.jl
@@ -124,7 +124,7 @@ seed!(123)
 seed!(456) # hide
 setprogress!(false) # hide
 
-@model robustreg(X, y; predictors=size(X, 2)) = begin
+@model function robustreg(X, y; predictors=size(X, 2))
     #priors
     νₐ ~ LogNormal(1, 1)
     νᵦ ~ LogNormal(1, 1)


### PR DESCRIPTION
This fixes the deprecated syntax:

```julia
@model model_name = begin
    ...
end
```

to the preferred `function` syntax:

```julia
@model function model_name
    ...
end
```