### PR TITLE
fix: update Turing.jl to 0.29

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,5 +24,5 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
-Turing = "0.27"
+Turing = "0.29"
 julia = "1"


### PR DESCRIPTION
Should fix `UndefVarError: `logpdf` not defined` and closes #83.