### PR TITLE
fix(08_ordinal_reg): export `transform!`

### DIFF
--- a/_literate/08_ordinal_reg.jl
+++ b/_literate/08_ordinal_reg.jl
@@ -95,6 +95,7 @@ using CairoMakie
 using AlgebraOfGraphics
 using Distributions
 using StatsFuns: logit
+using DataFrames: transform!
 
 # Here we have a discrete variable `x` with 6 possible ordered values as response.
 # The values range from 1 to 6 having probability, respectively:


### PR DESCRIPTION
Closes #83.
Somehow even with `using DataFrames` we are getting:

```shell
UndefVarError: `transform!` not defined
```

Hence, this might fix:

```julia
using DataFrames: transform!
```