### PR TITLE
fix: missing pages on deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __site/
+_rss/
 .DS_Store
 franklin
 franklin.pub

--- a/pages/01_why_Julia.md
+++ b/pages/01_why_Julia.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/01_why_Julia.jl}

--- a/pages/02_bayes_stats.md
+++ b/pages/02_bayes_stats.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/02_bayes_stats.jl}

--- a/pages/03_prob_dist.md
+++ b/pages/03_prob_dist.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/03_prob_dist.jl}

--- a/pages/04_Turing.md
+++ b/pages/04_Turing.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/04_Turing.jl}

--- a/pages/05_MCMC.md
+++ b/pages/05_MCMC.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/05_MCMC.jl}

--- a/pages/06_linear_reg.md
+++ b/pages/06_linear_reg.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/06_linear_reg.jl}

--- a/pages/07_logistic_reg.md
+++ b/pages/07_logistic_reg.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/07_logistic_reg.jl}

--- a/pages/08_ordinal_reg.md
+++ b/pages/08_ordinal_reg.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/08_ordinal_reg.jl}

--- a/pages/09_count_reg.md
+++ b/pages/09_count_reg.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/09_count_reg.jl}

--- a/pages/11_multilevel_models.md
+++ b/pages/11_multilevel_models.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/11_multilevel_models.jl}

--- a/pages/12_Turing_tricks.md
+++ b/pages/12_Turing_tricks.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/12_Turing_tricks.jl}

--- a/pages/13_epi_models.md
+++ b/pages/13_epi_models.md
@@ -4,6 +4,4 @@
 @def hascode = true
 @def mintoclevel = 2
 
-\toc
-
 \literate{/_literate/13_epi_models.jl}


### PR DESCRIPTION
Somehow `Franklin.jl` is erroring in some markdown pages because of the Table of Contents.

This is a quick and dirt fix to that:
removes the `toc` stuff.

Closes #90.