### PR TITLE
Problem with ToC and Heading Level 4

### DIFF
--- a/pages/01_why_Julia.md
+++ b/pages/01_why_Julia.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/01_why_Julia.jl}

--- a/pages/02_bayes_stats.md
+++ b/pages/02_bayes_stats.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/02_bayes_stats.jl}

--- a/pages/03_prob_dist.md
+++ b/pages/03_prob_dist.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/03_prob_dist.jl}

--- a/pages/04_Turing.md
+++ b/pages/04_Turing.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/04_Turing.jl}

--- a/pages/05_MCMC.md
+++ b/pages/05_MCMC.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/05_MCMC.jl}

--- a/pages/06_linear_reg.md
+++ b/pages/06_linear_reg.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/06_linear_reg.jl}

--- a/pages/07_logistic_reg.md
+++ b/pages/07_logistic_reg.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/07_logistic_reg.jl}

--- a/pages/08_ordinal_reg.md
+++ b/pages/08_ordinal_reg.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/08_ordinal_reg.jl}

--- a/pages/09_count_reg.md
+++ b/pages/09_count_reg.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/09_count_reg.jl}

--- a/pages/10_robust_reg.md
+++ b/pages/10_robust_reg.md
@@ -3,6 +3,7 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
 
 \toc
 

--- a/pages/11_multilevel_models.md
+++ b/pages/11_multilevel_models.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/11_multilevel_models.jl}

--- a/pages/12_Turing_tricks.md
+++ b/pages/12_Turing_tricks.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/12_Turing_tricks.jl}

--- a/pages/13_epi_models.md
+++ b/pages/13_epi_models.md
@@ -3,5 +3,8 @@
 @def showall = true
 @def hascode = true
 @def mintoclevel = 2
+@def maxtoclevel = 3
+
+\toc
 
 \literate{/_literate/13_epi_models.jl}


### PR DESCRIPTION
Hi again, 

This is about #90.  I haven’t used `Franklin.jl` before but I think this issue is about how it handles heading levels in ToC. If you have a heading level 4 (####), there is a render error with only `mintoclevel = 2`. So, I set the `maxtoclevel = 3`. Changing it to `maxtoclevel = 4` (with or without `mintoclevel`) also returns an error. Only chapters 2, 5 and 9 have level-4 headings, hence the errors in these chapters. 

I created a fresh website using `newsite()` and encountered the same problem with heading level-4. So, I think this is a bug in `Franklin.jl` (or something it uses). 